### PR TITLE
🎨 Palette: Enhance scannability and accessibility of the news digest

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,11 @@
 ## 2025-05-15 - [Accessibility and Contrast in HTML Emails]
 **Learning:** WCAG AA compliance (4.5:1) is crucial for readability in emails, especially on mobile. "Specialist" category colors often need manual darkening to remain accessible against white backgrounds. Contextual ARIA labels (like `aria-label="Read full article: {title}"`) solve the "ambiguous link text" problem when multiple "Read more" links exist on one page.
 **Action:** Always verify color contrast using a tool (or standard darker hex codes) and use semantic headers (`<h3>`) even when the visual design requires inline styling to mimic spans.
+
+## 2025-05-16 - [Scannability and Assistive Noise Reduction in Digests]
+**Learning:** For daily digests, scannability is paramount. Adding article counts to navigation and an estimated reading time significantly reduces the cognitive load for the user. Additionally, while emojis and decorative arrows provide visual delight, they create unnecessary noise for screen readers in an already dense email;  is essential for these elements.
+**Action:** Always include "at-a-glance" meta-info (counts, time) in headers and wrap all decorative glyphs in  spans.
+
+## 2025-05-16 - [Scannability and Assistive Noise Reduction in Digests]
+**Learning:** For daily digests, scannability is paramount. Adding article counts to navigation and an estimated reading time significantly reduces the cognitive load for the user. Additionally, while emojis and decorative arrows provide visual delight, they create unnecessary noise for screen readers in an already dense email; `aria-hidden="true"` is essential for these elements.
+**Action:** Always include "at-a-glance" meta-info (counts, time) in headers and wrap all decorative glyphs in `aria-hidden="true"` spans.

--- a/digest.py
+++ b/digest.py
@@ -190,19 +190,22 @@ Articles:
 
 
 def render_html(grouped, category_angles):
-    today = datetime.now().strftime("%B %d, %Y")
+    today = datetime.now().strftime("%A, %B %d, %Y")
     topics_present = list(grouped.keys())
+    total_articles = sum(len(articles) for articles in grouped.values())
+    reading_time = max(1, round(total_articles * 0.75))
 
     # Topic index bar
     index_bar_items = ""
     for topic in topics_present:
         color = TOPIC_COLORS[topic]
+        count = len(grouped[topic])
         # Sanitize anchor to only allow alphanumeric characters and hyphens
         anchor = re.sub(r"[^a-z0-9\-]", "", topic.replace(" ", "-").replace("&", "and").lower())
         index_bar_items += (
             f'<a href="#{anchor}" style="display:inline-block;margin:4px;padding:6px 14px;'
             f'background:{color};color:#fff;border-radius:20px;text-decoration:none;'
-            f'font-size:13px;font-weight:600;">{html.escape(topic)}</a>'
+            f'font-size:13px;font-weight:600;">{html.escape(topic)} ({count})</a>'
         )
 
     # Article sections
@@ -243,7 +246,7 @@ def render_html(grouped, category_angles):
               </p>
               <a href="{safe_link}" aria-label="Read full article: {safe_title}"
                  style="color:{color};font-size:13px;font-weight:600;
-                 text-decoration:none;">Read full article &rarr;</a>
+                 text-decoration:none;">Read full article <span aria-hidden="true">&rarr;</span></a>
             </div>"""
 
         angles = category_angles.get(topic, [])
@@ -257,7 +260,9 @@ def render_html(grouped, category_angles):
           <div style="background:#fefce8;border-left:4px solid #f59e0b;
                       padding:12px 16px;border-radius:4px;margin-bottom:20px;">
             <h3 style="margin:0;display:inline;font-size:12px;font-weight:700;color:#b45309;
-                         text-transform:uppercase;letter-spacing:0.5px;">UPSC Exam Angles</h3>
+                         text-transform:uppercase;letter-spacing:0.5px;">
+              <span aria-hidden="true">🎓</span> UPSC Exam Angles
+            </h3>
             <ul style="margin:8px 0 0 0;padding-left:18px;">{bullets}</ul>
           </div>"""
 
@@ -270,7 +275,7 @@ def render_html(grouped, category_angles):
           {angles_html}
           {cards_html}
           <div style="text-align:right;">
-            <a href="#top" style="color:#666;font-size:12px;text-decoration:none;">&uarr; Back to top</a>
+            <a href="#top" style="color:#666;font-size:12px;text-decoration:none;"><span aria-hidden="true">&uarr;</span> Back to top</a>
           </div>
         </div>"""
 
@@ -289,7 +294,7 @@ def render_html(grouped, category_angles):
       <h1 style="color:#fff;margin:0 0 6px 0;font-size:26px;font-weight:700;">
         UPSC News Digest
       </h1>
-      <p style="color:#aaa;margin:0;font-size:14px;">{today}</p>
+      <p style="color:#aaa;margin:0;font-size:14px;">{today} &bull; {total_articles} articles &bull; {reading_time} min read</p>
     </div>
 
     <!-- Topic Index Bar -->


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the UPSC News Digest email:

💡 **What:** 
- **Header info:** Now includes the day of the week, total article count, and estimated reading time.
- **Topic Index:** Now shows the number of articles in each category (e.g., "Economy (3)").
- **Visual Delight:** Added a graduation cap emoji (🎓) to the "UPSC Exam Angles" header.
- **Accessibility:** Wrapped decorative arrows (→, ↑) and the new emoji in `aria-hidden="true"` spans.

🎯 **Why:** 
Users of daily digests need to quickly gauge the volume of news and prioritize their reading. The added counts and reading time provide immediate context. The accessibility fixes ensure that screen reader users aren't interrupted by purely decorative characters.

♿ **Accessibility:** 
- Decorative characters now hidden from screen readers.
- Contextual `aria-label` for "Read full article" links (pre-existing, but maintained).

Verified locally with Playwright screenshots.

---
*PR created automatically by Jules for task [6213817154483260130](https://jules.google.com/task/6213817154483260130) started by @kavyabarnadhya*