### PR TITLE
🎨 Palette: Accessibility and Inbox Experience Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-17 - [Semantic Structure in Email Digests]
 **Learning:** Transitioning from generic `<div>` stacks to semantic HTML (`<article>`, `<h3>`, `<ul>`, `<main>`) significantly improves the experience for assistive technology users without impacting visual design. Screen readers can use landmark navigation (`<main>`) and structural navigation (headings and articles) to quickly parse a dense daily digest.
 **Action:** Use semantic landmarks and heading levels in email templates, even when visual consistency requires complex inline styling to match previous non-semantic designs.
+
+## 2025-05-18 - [Email-Safe Accessibility Controls]
+**Learning:** For email accessibility features like "Skip to Content" links, avoid JavaScript handlers (`onfocus`) as most email clients strip them. A `<style>` block using `:focus` classes is more robust, though still not supported by all clients (e.g., Gmail on mobile). Always provide descriptive `aria-label` attributes for navigational links even if they contain text, as it provides clearer intent for screen reader users (e.g., "Jump to section" vs just "Economy").
+**Action:** Prioritize CSS-based focus states over JavaScript for email interactivity and use descriptive ARIA labels to clarify navigational intent.

--- a/digest.py
+++ b/digest.py
@@ -232,13 +232,15 @@ def render_html(grouped, category_angles):
     for topic in topics_present:
         color = TOPIC_COLORS.get(topic, "#555")
         count = len(grouped[topic])
+        safe_name = SAFE_TOPIC_NAMES.get(topic, html.escape(topic))
         # Use fallback if topic was not in the original TOPIC_COLORS
         anchor = TOPIC_ANCHORS.get(topic, re.sub(r"[^a-z0-9\-]", "", topic.replace(" ", "-").replace("&", "and").lower()))
         index_bar_parts.append(
             f'<li style="display:inline-block;margin:0;">'
-            f'<a href="#{anchor}" style="display:inline-block;margin:4px;padding:6px 14px;'
+            f'<a href="#{anchor}" aria-label="Jump to {safe_name} section - {count} articles" '
+            f'style="display:inline-block;margin:4px;padding:6px 14px;'
             f'background:{color};color:#fff;border-radius:20px;text-decoration:none;'
-            f'font-size:13px;font-weight:600;">{SAFE_TOPIC_NAMES[topic]} ({count})</a>'
+            f'font-size:13px;font-weight:600;">{safe_name} ({count})</a>'
             f'</li>'
         )
     index_bar_items = f'<ul style="list-style:none;padding:0;margin:0;">{"".join(index_bar_parts)}</ul>'
@@ -248,6 +250,7 @@ def render_html(grouped, category_angles):
     for topic in topics_present:
         color = TOPIC_COLORS.get(topic, "#555")
         anchor = TOPIC_ANCHORS.get(topic, re.sub(r"[^a-z0-9\-]", "", topic.replace(" ", "-").replace("&", "and").lower()))
+        header_id = f"header-{anchor}"
         articles = grouped[topic]
 
         cards_parts = []
@@ -304,19 +307,22 @@ def render_html(grouped, category_angles):
           </div>"""
 
         sections_parts.append(f"""
-        <div id="{anchor}" style="margin-bottom:36px;">
-          <h2 style="margin:0 0 16px 0;padding:12px 20px;background:{color};
+        <section id="{anchor}" aria-labelledby="{header_id}" style="margin-bottom:36px;">
+          <h2 id="{header_id}" style="margin:0 0 16px 0;padding:12px 20px;background:{color};
                      color:#fff;border-radius:6px;font-size:18px;font-weight:700;">
             {SAFE_TOPIC_NAMES.get(topic, html.escape(topic))}
           </h2>
           {angles_html}
           {cards_html}
           <div style="text-align:right;">
-            <a href="#top" style="color:#666;font-size:12px;text-decoration:none;"><span aria-hidden="true">&uarr;</span> Back to top</a>
+            <a href="#top" aria-label="Back to topic index" style="color:#666;font-size:12px;text-decoration:none;"><span aria-hidden="true">&uarr;</span> Back to top</a>
           </div>
-        </div>""")
+        </section>""")
 
     sections_html = "".join(sections_parts)
+
+    # Preheader text for better inbox preview
+    preheader_text = f"Today's UPSC Digest: {total_articles} curated articles across {len(topics_present)} topics. Reading time: {reading_time} min."
 
     full_html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -324,9 +330,31 @@ def render_html(grouped, category_angles):
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>UPSC News Digest – {today}</title>
+  <style>
+    .skip-link:focus {{
+      position: static !important;
+      width: auto !important;
+      height: auto !important;
+      overflow: visible !important;
+      background: #fff;
+      padding: 10px;
+      border: 2px solid #1a1a2e;
+      z-index: 9999;
+    }}
+  </style>
 </head>
 <body style="margin:0;padding:0;background:#f5f5f5;font-family:Arial,sans-serif;">
+  <!-- Preheader -->
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;" aria-hidden="true">
+    {html.escape(preheader_text)}
+  </div>
+
   <div id="top" style="max-width:680px;margin:0 auto;padding:20px;">
+    <!-- Skip to content -->
+    <a href="#main-content" class="skip-link"
+       style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">
+       Skip to content
+    </a>
 
     <!-- Header -->
     <div style="background:#1a1a2e;border-radius:10px;padding:28px 30px;margin-bottom:24px;text-align:center;">
@@ -345,7 +373,7 @@ def render_html(grouped, category_angles):
     </nav>
 
     <!-- Article Sections -->
-    <main>
+    <main id="main-content">
       {sections_html}
     </main>
 


### PR DESCRIPTION
This PR implements several micro-UX and accessibility improvements to the UPSC News Digest email template:

1.  **Email Preheader**: Added a hidden `div` with a summary of the digest (article count, topic count, and reading time) which appears as the preview text in email clients like Gmail and Outlook.
2.  **Skip to Content Link**: Added a hidden link at the top of the email that becomes visible on focus, allowing keyboard and screen reader users to jump straight to the news content. This was implemented using a CSS-based approach (in a `<style>` block) to ensure compatibility with email clients that strip JavaScript.
3.  **Semantic Landmarks**: Refactored the generic `div` layout to use semantic `<main>` and `<section>` tags. Sections are correctly labeled using `aria-labelledby` pointing to their respective topic headers, significantly improving navigation for screen reader users.
4.  **Descriptive Navigation**: Enhanced navigation links (both in the topic index and the "Back to top" links) with descriptive `aria-label` attributes to provide clearer context for assistive technologies.
5.  **Journaling**: Documented these email-specific accessibility patterns in `.jules/palette.md` for future reference.

Accessibility verified through manual HTML inspection and visual screenshot capture. Core logic remains unaffected as confirmed by existing tests.

---
*PR created automatically by Jules for task [2846989596895228962](https://jules.google.com/task/2846989596895228962) started by @kavyabarnadhya*