### PR TITLE
🎨 Palette: Bold GS paper references for better scannability

### DIFF
--- a/digest.py
+++ b/digest.py
@@ -23,6 +23,9 @@ socket.setdefaulttimeout(30)
 # Pre-compiled regex for stripping HTML tags; more efficient than calling re.sub in a loop
 TAG_RE = re.compile(r"<[^>]+>")
 
+# Pre-compiled regex for bolding GS paper references (GS-I to GS-IV) for better scannability
+GS_RE = re.compile(r"(GS-[IVX]+)")
+
 
 def clean_text(text):
     """
@@ -279,6 +282,8 @@ def render_html(grouped, category_angles):
             safe_title = html.escape(a.get("title", ""))
             safe_source = html.escape(a.get("source", ""))
             safe_summary = html.escape(a.get("summary", ""))
+            # UX: Bold GS paper references to help UPSC aspirants scan the digest more efficiently
+            safe_summary = GS_RE.sub(r"<strong>\1</strong>", safe_summary)
 
             # Simple URL validation: only allow http(s) protocols
             # Security: Validation must be case-insensitive to effectively block javascript: URIs
@@ -312,8 +317,10 @@ def render_html(grouped, category_angles):
         # Security: Ensure angles is a list to prevent iterating over characters if AI returns a string
         if isinstance(angles, list) and angles:
             # Security: Defensive string conversion to prevent crashes on non-string AI output
+            # UX: Bold GS paper references to help UPSC aspirants scan the digest more efficiently
             bullets = "".join(
-                f'<li style="margin:4px 0;color:#78350f;font-size:13px;line-height:1.5;">{html.escape(str(b))}</li>'
+                f'<li style="margin:4px 0;color:#78350f;font-size:13px;line-height:1.5;">'
+                f'{GS_RE.sub(r"<strong>\1</strong>", html.escape(str(b)))}</li>'
                 for b in angles
             )
             angles_html = f"""


### PR DESCRIPTION
### 🎨 Palette: Bold GS paper references for better scannability

#### 💡 What:
I have added a micro-UX enhancement that automatically bolds General Studies (GS) paper references (e.g., **GS-I**, **GS-II**, **GS-III**, **GS-IV**) within the article summaries and the "UPSC Exam Angles" section of the email digest.

#### 🎯 Why:
UPSC aspirants (the target audience for this app) often prioritize articles based on which GS paper they map to. By bolding these references, the digest becomes significantly easier to scan at a glance, allowing users to find relevant content faster.

#### ♿ Accessibility & UX:
- **Scannability:** Highlighting key academic categories reduces cognitive load.
- **Safety:** The bolding is applied using a regex substitution *after* HTML escaping, ensuring that the `<strong>` tags are safe and correctly rendered as HTML, while the source content remains sanitized against XSS.

#### 📸 Verification:
- Verified that "GS-II", "GS-III", and "GS-IV" are correctly bolded in both summaries and bullet points.
- Ran existing tests and linting (`ruff`).
- Visual verification performed via Playwright.

---
*PR created automatically by Jules for task [17436581976229527575](https://jules.google.com/task/17436581976229527575) started by @kavyabarnadhya*