### PR TITLE
Fix validate_env() to handle empty receiver email addresses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Application crashes or insecure behavior due to missing environment variables or malformed data from external sources (RSS/LLM).
 **Learning:** External data should never be assumed to be of a specific type (e.g., LLMs might return non-strings). Missing env vars should be caught at startup rather than mid-execution.
 **Prevention:** Implement a `validate_env()` function to check all required secrets and basic formats at boot. Use `isinstance(var, str)` and explicit `str()` conversion for all dynamic data before processing for HTML.
+
+## 2026-05-06 - validate_env() Bug: Empty-String Handling in RECEIVER_EMAIL
+**Incident:** The `validate_env()` function introduced in the Sentinel PR caused 3 consecutive daily workflow failures. The RECEIVER_EMAIL regex check iterated over all entries from `.split(",")` without filtering empty strings first. A trailing comma in the secret (e.g. `user@example.com,`) produces an empty string that fails the regex, raising a ValueError → exit(1).
+**Fix:** Filter empty entries before validation: `[r.strip() for r in val.split(",") if r.strip()]`
+**Lesson:** Always mirror the same split/filter logic used in `send_email()` when validating the same field. **Do NOT modify `validate_env()` or email-handling logic without running `python -m unittest test_parallel_logic.py` AND manually testing the validate_env paths.** For security-sensitive functions, add unit tests before and after changes.

--- a/digest.py
+++ b/digest.py
@@ -442,10 +442,12 @@ def validate_env():
     if not email_regex.match(sender):
         raise ValueError("SENDER_EMAIL does not appear to be a valid email address.")
 
-    receivers = os.getenv("RECEIVER_EMAIL", "").split(",")
+    receivers = [r.strip() for r in os.getenv("RECEIVER_EMAIL", "").split(",") if r.strip()]
+    if not receivers:
+        raise ValueError("RECEIVER_EMAIL is empty or contains no valid addresses")
     for r in receivers:
-        if not email_regex.match(r.strip()):
-            raise ValueError(f"RECEIVER_EMAIL contains an invalid email address: {r.strip()}")
+        if not email_regex.match(r):
+            raise ValueError(f"RECEIVER_EMAIL contains an invalid email address: {r}")
 
 
 def send_email(html_body):
@@ -550,7 +552,7 @@ if __name__ == "__main__":
         for a in classified:
             grouped_raw[a["topic"]].append(a)
         grouped = {t: grouped_raw[t] for t in TOPIC_ORDER if t in grouped_raw}
-        html = render_html(grouped, category_angles)
+        html_body = render_html(grouped, category_angles)
         print(f"  Topics covered: {', '.join(grouped.keys())}")
     except Exception as e:
         print(f"FATAL: HTML rendering failed: {e}")
@@ -558,7 +560,7 @@ if __name__ == "__main__":
 
     print("\n[4/4] Sending email via Gmail SMTP...")
     try:
-        send_email(html)
+        send_email(html_body)
         print("  Email sent successfully!")
     except Exception as e:
         print(f"FATAL: Email sending failed: {e}")


### PR DESCRIPTION
## Summary
Fix a bug in `validate_env()` where trailing commas or whitespace-only entries in the `RECEIVER_EMAIL` environment variable would cause validation to fail. The function now properly filters empty strings before regex validation, matching the logic used in `send_email()`.

## Changes
- **validate_env()**: Updated `RECEIVER_EMAIL` parsing to strip whitespace and filter empty entries before validation
  - Changed from: `os.getenv("RECEIVER_EMAIL", "").split(",")`
  - Changed to: `[r.strip() for r in os.getenv("RECEIVER_EMAIL", "").split(",") if r.strip()]`
  - Added explicit check to raise `ValueError` if no valid addresses remain after filtering
  - Removed redundant `.strip()` calls in the validation loop since entries are pre-stripped

- **send_email()**: Fixed variable naming inconsistency
  - Renamed `html` to `html_body` for consistency with function signature and clarity

## Implementation Details
The bug occurred because `validate_env()` was iterating over raw split results without filtering empty strings first. A trailing comma in the secret (e.g., `user@example.com,`) would produce an empty string that fails email regex validation, causing the application to exit at startup.

The fix ensures the same split/filter logic is applied consistently across both validation and email-sending code paths, preventing runtime failures in production workflows.

https://claude.ai/code/session_012eYJMixKE9qTmiGWSbww58