### PR TITLE
⚡ Bolt: Deduplicate articles by URL to save tokens and time

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,11 @@
 ## 2026-05-18 - [Optimization Trap: Overlapping Pattern Replacement]
 **Learning:** Replacing regex with iterative `str.replace()` for overlapping patterns (e.g., 'GS-I' and 'GS-II') or when the replacement contains the search pattern is unsafe. It can cause duplicate bolding or corrupt existing HTML tags (e.g., matching 'GS-I' inside '<strong>GS-II</strong>').
 **Action:** Use `re.sub` for correct token matching when dealing with overlapping patterns or HTML injection.
+
+## 2026-06-12 - [Article Deduplication across multi-source feeds]
+**Learning:** In applications aggregating news from multiple overlapping sources, the same article often appears in different feeds. Deduplicating these by URL () before LLM processing significantly reduces token costs and classification overhead.
+**Action:** Implement a `seen_links` set during article collection phases (main and expansion) to filter out redundant content before it reaches the LLM or final rendering.
+
+## 2026-06-12 - [Article Deduplication across multi-source feeds]
+**Learning:** In applications aggregating news from multiple overlapping sources, the same article often appears in different feeds. Deduplicating these by URL (`link`) before LLM processing significantly reduces token costs and classification overhead.
+**Action:** Implement a `seen_links` set during article collection phases (main and expansion) to filter out redundant content before it reaches the LLM or final rendering.

--- a/digest.py
+++ b/digest.py
@@ -193,6 +193,7 @@ def fetch_from_feed(url, source_name, limit=3):
 
 
 def fetch_articles():
+    """Fetch articles from all main feeds and deduplicate by URL."""
     articles = []
     with ThreadPoolExecutor(max_workers=len(FEEDS)) as executor:
         futures = []
@@ -201,8 +202,14 @@ def fetch_articles():
             # so they don't crowd out other categories. General sources get 5.
             limit = 3 if source in SPECIALIST_SOURCES else 5
             futures.append(executor.submit(fetch_from_feed, url, source, limit))
+
+        seen_links = set()
         for future in futures:
-            articles.extend(future.result())
+            for article in future.result():
+                link = article.get("link")
+                if link and link not in seen_links:
+                    articles.append(article)
+                    seen_links.add(link)
     return articles
 
 
@@ -557,6 +564,8 @@ if __name__ == "__main__":
     print("\n[1/4] Fetching articles from RSS feeds...")
     try:
         articles = fetch_articles()
+        # Track unique links to avoid duplicates in expansion pass
+        seen_links = {a["link"] for a in articles}
         print(f"  Total fetched: {len(articles)} articles")
     except Exception as e:
         print(f"FATAL: Could not fetch articles: {e}")
@@ -592,7 +601,11 @@ if __name__ == "__main__":
                 source_name = url.split("/")[2][:50]  # e.g. thewire.in
                 futures.append(executor.submit(fetch_from_feed, url, source_name, limit=3))
             for future in futures:
-                expansion_articles.extend(future.result())
+                for article in future.result():
+                    link = article.get("link")
+                    if link and link not in seen_links:
+                        expansion_articles.append(article)
+                        seen_links.add(link)
 
         if expansion_articles:
             print(f"  Classifying {len(expansion_articles)} expansion articles...")


### PR DESCRIPTION
### 💡 What:
Implemented URL-based article deduplication in `digest.py`.

### 🎯 Why:
The application aggregates news from multiple India-focused sources. Often, the same story is published across multiple feeds (e.g., The Hindu and Indian Express). Without deduplication, the LLM processes the same content multiple times, wasting tokens and increasing processing latency.

### 📊 Impact:
- **Efficiency:** Reduces LLM token consumption by filtering redundant articles before classification.
- **Speed:** Faster classification pass due to fewer articles being sent to the LLM.
- **Data Quality:** Prevents duplicate article cards from appearing in the final email digest.
- **Estimated Savings:** Up to 85% reduction in LLM input size when major news is shared across all 7 sources.

### 🔬 Measurement:
Verified using a benchmark script with mocked RSS responses where 7 feeds returned the same article URL. The logic correctly reduced the batch from 7 articles to 1 unique article before LLM processing.

---
*PR created automatically by Jules for task [14104183966498955168](https://jules.google.com/task/14104183966498955168) started by @kavyabarnadhya*