### PR TITLE
🛡️ Sentinel: [HIGH] Fix Prompt Injection Risk via LLM Role Separation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,9 @@
 **Learning:** AI-generated content should be treated as untrusted input. Trusting indices returned by an LLM without deduplication and bounding can lead to unbounded iteration or payload growth.
 **Fix:** Extracted LLM processing into `process_llm_articles()` with strict bounds: capped input iteration at 100, deduplicated indices via a `seen_indices` set, capped final article count at 50, and limited category topics to 20.
 **Prevention:** Always implement hard bounds and deduplication when mapping untrusted identifiers (like indices) back to internal data structures.
+
+## 2026-05-30 - LLM Role Separation for Injection Defense
+**Vulnerability:** Prompt injection risk where untrusted article data could override system instructions if both are sent in a single 'user' message.
+**Learning:** Sending instructions and untrusted data in the same message makes it easier for an attacker (or malformed input) to manipulate the model's behavior.
+**Fix:** Separated persona and instructions into a 'system' message, while keeping the external article data in a 'user' message.
+**Prevention:** Always use the 'system' role for static instructions and the 'user' role for dynamic/untrusted data to leverage the model's internal role-based priority and boundary enforcement.

--- a/digest.py
+++ b/digest.py
@@ -287,7 +287,9 @@ def classify_articles(articles):
         )
     articles_text = "".join(articles_text_parts)
 
-    prompt = f"""You are a UPSC exam preparation assistant focused on the Indian Civil Services Examination.
+    # Security: Use separate System message for instructions and persona, and User message
+    # for untrusted article data to mitigate prompt injection risks.
+    system_prompt = f"""You are a UPSC exam preparation assistant focused on the Indian Civil Services Examination.
 
 **Priority:** Strongly prefer articles with a direct India angle — Indian polity, governance, legislation, constitutional matters, Indian economy, Indian social issues, Indian environment policy, Indian science initiatives, India's defence, or Indian history and culture.
 
@@ -304,15 +306,17 @@ Return ONLY a JSON object (no markdown, no code fences, no explanation) with exa
    - summary: sharp UPSC-focused summary in 4-5 sentences. Lead with the core decision, judgment, or policy. Then include: (a) the specific constitutional article, act, scheme, or regulatory body involved by name; (b) one or two concrete data points such as numbers, percentages, timelines, or committee names; (c) the GS paper and syllabus topic this maps to (e.g. "GS-II: Parliament and State Legislatures"); (d) the exam-relevant implication or significance. Avoid generic commentary, journalistic opinion, and vague statements like "experts say" or "this is significant".
    Omit articles that are "Not UPSC Relevant" — do not include them in the array at all.
 
-2. "category_angles": an object mapping each topic that appeared in "articles" to an array of 3-5 bullet strings highlighting the collective UPSC exam relevance of all articles under that topic (mention specific GS papers, syllabus topics, or exam themes where applicable).
+2. "category_angles": an object mapping each topic that appeared in "articles" to an array of 3-5 bullet strings highlighting the collective UPSC exam relevance of all articles under that topic (mention specific GS papers, syllabus topics, or exam themes where applicable)."""
 
-Articles:
-{articles_text}"""
+    user_content = f"Articles to process:\n{articles_text}"
 
     try:
         response = client.chat.completions.create(
             model="llama-3.3-70b-versatile",
-            messages=[{"role": "user", "content": prompt}],
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content}
+            ],
             temperature=0.2,
             max_tokens=8000,
             response_format={"type": "json_object"},


### PR DESCRIPTION
🛡️ Sentinel: implement LLM role separation for prompt injection defense

Refactored `classify_articles` in `digest.py` to use separate 'system' and 'user' roles for the Groq API call. By moving static instructions and persona to a system message and untrusted article data to a user message, we leverage the model's internal role-based priority and boundary enforcement, providing a defense-in-depth measure against prompt injection.

- Modified `digest.py` to separate prompt roles.
- Added security learning to `.jules/sentinel.md`.
- Verified via unit tests mocking the Groq client.

---
*PR created automatically by Jules for task [10141292022564707533](https://jules.google.com/task/10141292022564707533) started by @kavyabarnadhya*