### PR TITLE
🛡️ Sentinel: Enforce RSS URL Whitelisting & Secure TLS Protocol

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** Risk of prompt injection where malicious or malformed RSS content could spoof custom delimiters (e.g., "--- Article X ---") to manipulate LLM classification or summary output.
 **Learning:** Custom string delimiters are fragile and easily spoofed by untrusted content. LLMs are highly proficient at parsing standard structured formats like JSON, which provides a more robust structural boundary between instruction and data.
 **Prevention:** Always use `json.dumps()` to wrap untrusted data arrays or objects before sending them to an LLM. Update system prompts to explicitly state that input will be provided in JSON format to reinforce structural expectations.
+
+## 2026-07-12 - RSS Feed URL Whitelisting & Secure TLS Protocols
+**Vulnerability:** Risk of Server-Side Request Forgery (SSRF), unauthorized outgoing network requests, or TLS protocol downgrade attacks on SMTP connections.
+**Learning:** Even if the application currently uses a fixed list of static RSS feeds, dynamically fetched URL parameters are vulnerable if downstream modules are modified. In addition, default SSL contexts can sometimes allow weak legacy protocols depending on the client system configuration.
+**Prevention:** Define a strict whitelisted set of URLs (`ALLOWED_FEEDS`) at module load time and reject any feeds outside this set. Enforce a minimum TLS version of TLSv1.2 (`context.minimum_version = ssl.TLSVersion.TLSv1_2`) explicitly on mail server contexts to prevent downgrade attacks.

--- a/digest.py
+++ b/digest.py
@@ -135,6 +135,9 @@ EXPANSION_FEEDS = {
     ],
 }
 
+# Security: Whitelist of allowed RSS feed URLs to prevent SSRF and unauthorized outgoing requests
+ALLOWED_FEEDS = set(FEEDS.values()) | {url for urls in EXPANSION_FEEDS.values() for url in urls}
+
 TOPIC_COLORS = {
     "International Relations": "#c0392b",
     "Economy": "#196f3d",
@@ -248,6 +251,9 @@ def fetch_from_feed(url, source_name, limit=3):
     # Security: Enforce web protocols for all RSS feeds to prevent local file disclosure (LFD)
     if not isinstance(url, str) or not url.lower().startswith(("http://", "https://")):
         raise ValueError(f"Secure protocol required: HTTP or HTTPS. Received: {url}")
+    # Security: Restrict fetching to whitelisted RSS feed URLs to prevent SSRF and unauthorized requests
+    if url not in ALLOWED_FEEDS:
+        raise ValueError(f"Unauthorized feed URL: {url}")
 
     articles = []
     try:
@@ -815,6 +821,8 @@ def send_email(html_body, total_articles=None, reading_time=None):
 
     today = datetime.now().strftime("%B %d, %Y")
     context = ssl.create_default_context()
+    # Security: Enforce minimum TLS version of TLSv1.2 to prevent protocol downgrade attacks
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
 
     # Performance Optimization: Pre-calculate the MIMEText body part once outside the loop
     # to avoid redundant re-encoding and memory allocation cycles for each recipient.

--- a/test_security.py
+++ b/test_security.py
@@ -143,5 +143,49 @@ class TestSecurity(unittest.TestCase):
         # The separator is \x00. We must ensure it's not in the result.
         self.assertNotIn("\x00", classified_encoded[0]["summary"])
 
+    @patch("digest.feedparser.parse")
+    def test_fetch_from_feed_whitelist(self, mock_parse):
+        # Setup mock_parse to return empty entries
+        mock_parse.return_value.entries = []
+
+        # Unauthorized URL should raise ValueError
+        with self.assertRaisesRegex(ValueError, "Unauthorized feed URL"):
+            digest.fetch_from_feed("https://unauthorized.domain.com/feed", "Unauthorized")
+
+        # Authorized URL should pass whitelist check and call feedparser
+        # Get one of the whitelisted URLs
+        authorized_url = list(digest.ALLOWED_FEEDS)[0]
+        try:
+            digest.fetch_from_feed(authorized_url, "Authorized")
+        except Exception as e:
+            self.fail(f"fetch_from_feed raised unexpected exception on authorized URL: {e}")
+
+        mock_parse.assert_called_once_with(authorized_url)
+
+    @patch("digest.smtplib.SMTP_SSL")
+    @patch("digest.os.getenv")
+    def test_send_email_enforces_tls_version(self, mock_getenv, mock_smtp):
+        # Setup env variables
+        mock_getenv.side_effect = lambda key, default=None: {
+            "SENDER_EMAIL": "sender@test.test",
+            "SENDER_APP_PASSWORD": "abcd efgh ijkl mnop",
+            "RECEIVER_EMAIL": "receiver@test.test"
+        }.get(key, default)
+
+        # Call send_email with dummy body
+        try:
+            digest.send_email("<html></html>", 0, 0)
+        except Exception:
+            pass # We only care about the SSL context passed to SMTP_SSL
+
+        # SMTP_SSL is called with (host, port, context=context, timeout=30)
+        # Check that it was called, and that the context keyword argument had minimum_version set
+        self.assertTrue(mock_smtp.called)
+        kwargs = mock_smtp.call_args[1]
+        context = kwargs.get("context")
+        self.assertIsNotNone(context)
+        import ssl
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Enforced strict RSS URL whitelisting to mitigate SSRF risks and configured SSL contexts to enforce TLSv1.2 minimum version, preventing protocol downgrade attacks on SMTP email dispatches. Added comprehensive security unit tests and updated Sentinel's Journal.

---
*PR created automatically by Jules for task [8704993399992167159](https://jules.google.com/task/8704993399992167159) started by @kavyabarnadhya*