### PR TITLE
⚡ Bolt: Pre-clean source_name parameter outside fetch loop

### DIFF
--- a/digest.py
+++ b/digest.py
@@ -257,6 +257,8 @@ def fetch_from_feed(url, source_name, limit=3):
 
     articles = []
     try:
+        # Performance Optimization: Pre-clean constant source_name outside of loop to save redundant clean_text CPU cycles
+        clean_source = clean_text(source_name, max_len=100)
         feed = feedparser.parse(url)
         for entry in feed.entries[:limit]:
             raw_summary = getattr(entry, "summary", "") or getattr(entry, "description", "")
@@ -269,7 +271,7 @@ def fetch_from_feed(url, source_name, limit=3):
                 "title": clean_text(str(entry.get("title", "")), max_len=200),
                 "link":  clean_text(str(entry.get("link", "")), max_len=500),
                 "summary": summary,
-                "source": clean_text(source_name, max_len=100),
+                "source": clean_source,
             })
         print(f"  [{source_name}] fetched {len(articles)} articles")
     except Exception as e:


### PR DESCRIPTION
Moved source name cleaning via `clean_text` outside of the entry-fetching loop in `fetch_from_feed` since it is a loop-invariant string. This saves redundant CPU cycles and speeds up feed fetching.

---
*PR created automatically by Jules for task [10413549135856390358](https://jules.google.com/task/10413549135856390358) started by @kavyabarnadhya*