### PR TITLE
🛡️ Sentinel: Safe RSS Data Fetching and DoS Mitigation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** Risk of Server-Side Request Forgery (SSRF), unauthorized outgoing network requests, or TLS protocol downgrade attacks on SMTP connections.
 **Learning:** Even if the application currently uses a fixed list of static RSS feeds, dynamically fetched URL parameters are vulnerable if downstream modules are modified. In addition, default SSL contexts can sometimes allow weak legacy protocols depending on the client system configuration.
 **Prevention:** Define a strict whitelisted set of URLs (`ALLOWED_FEEDS`) at module load time and reject any feeds outside this set. Enforce a minimum TLS version of TLSv1.2 (`context.minimum_version = ssl.TLSVersion.TLSv1_2`) explicitly on mail server contexts to prevent downgrade attacks.
+
+## 2026-07-19 - Safe RSS Data Fetching and Resource Exhaustion (DoS) Mitigation
+**Vulnerability:** Denial of Service (DoS) / Out-Of-Memory (OOM) crashes if external RSS feed servers return excessively large payloads or infinite streams during fetching.
+**Learning:** `feedparser.parse(url)` fetches URLs using raw, unbounded urllib requests without response content length limits. Passing raw URLs to third-party parsing libraries exposes the application to resource exhaustion or decompression bomb payloads.
+**Prevention:** Explicitly fetch RSS feed data using a custom `urllib.request` handler. Set an explicit network `timeout`, enforce a strict content length limit, truncate/verify stream data reading, use a secure SSL/TLS context enforcing `TLSv1.2` minimum, and pass parsed byte payloads and headers to `feedparser`.

--- a/digest.py
+++ b/digest.py
@@ -5,6 +5,7 @@ import smtplib
 import socket
 import ssl
 import html
+import urllib.request
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import collections
@@ -246,6 +247,41 @@ TOPIC_ORDER = [
 ]
 
 
+def fetch_feed_data_safely(url, timeout=15, max_bytes=10 * 1024 * 1024):
+    """
+    Security Enhancement: Safely fetch the RSS feed content with a strict size limit,
+    explicit timeout, and secure SSL context to prevent Resource Exhaustion (DoS),
+    unintended file disclosure, and SSL downgrade/bypass attacks.
+    """
+    # Create a secure SSL context enforcing minimum TLSv1.2
+    context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "UPSC-News-Digest/1.0"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout, context=context) as response:
+        content_length = response.headers.get("Content-Length")
+        if content_length:
+            try:
+                length_val = int(content_length)
+            except ValueError:
+                length_val = None
+
+            if length_val is not None and length_val > max_bytes:
+                raise ValueError(f"Feed content too large: {content_length} bytes")
+
+        data = response.read(max_bytes)
+        # If there's still more data, raise ValueError to prevent DoS via infinite stream
+        if response.read(1):
+            raise ValueError(f"Feed content exceeds maximum size of {max_bytes} bytes")
+
+        headers = dict(response.headers)
+        headers["content-location"] = url
+        return data, headers
+
+
 def fetch_from_feed(url, source_name, limit=3):
     """Fetch up to `limit` articles from a single RSS feed URL."""
     # Security: Enforce web protocols for all RSS feeds to prevent local file disclosure (LFD)
@@ -259,7 +295,11 @@ def fetch_from_feed(url, source_name, limit=3):
     try:
         # Performance Optimization: Pre-clean constant source_name outside of loop to save redundant clean_text CPU cycles
         clean_source = clean_text(source_name, max_len=100)
-        feed = feedparser.parse(url)
+
+        # Security: Fetch feed securely with strict limits to prevent DoS and insecure SSL config
+        data, headers = fetch_feed_data_safely(url)
+        feed = feedparser.parse(data, response_headers=headers)
+
         for entry in feed.entries[:limit]:
             raw_summary = getattr(entry, "summary", "") or getattr(entry, "description", "")
             # Apply clean_text early to save memory and token budget

--- a/test_security.py
+++ b/test_security.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import os
 import digest
 
@@ -143,8 +143,15 @@ class TestSecurity(unittest.TestCase):
         # The separator is \x00. We must ensure it's not in the result.
         self.assertNotIn("\x00", classified_encoded[0]["summary"])
 
+    @patch("digest.urllib.request.urlopen")
     @patch("digest.feedparser.parse")
-    def test_fetch_from_feed_whitelist(self, mock_parse):
+    def test_fetch_from_feed_whitelist(self, mock_parse, mock_urlopen):
+        # Setup mock_urlopen to return mock data and headers safely
+        mock_response = MagicMock()
+        mock_response.read.side_effect = [b"<rss></rss>", b""]
+        mock_response.headers = {"Content-Type": "text/xml"}
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
         # Setup mock_parse to return empty entries
         mock_parse.return_value.entries = []
 
@@ -153,14 +160,36 @@ class TestSecurity(unittest.TestCase):
             digest.fetch_from_feed("https://unauthorized.domain.com/feed", "Unauthorized")
 
         # Authorized URL should pass whitelist check and call feedparser
-        # Get one of the whitelisted URLs
         authorized_url = list(digest.ALLOWED_FEEDS)[0]
         try:
             digest.fetch_from_feed(authorized_url, "Authorized")
         except Exception as e:
             self.fail(f"fetch_from_feed raised unexpected exception on authorized URL: {e}")
 
-        mock_parse.assert_called_once_with(authorized_url)
+        expected_headers = {"Content-Type": "text/xml", "content-location": authorized_url}
+        mock_parse.assert_called_once_with(b"<rss></rss>", response_headers=expected_headers)
+
+    @patch("digest.urllib.request.urlopen")
+    def test_fetch_feed_data_safely_oversized_headers(self, mock_urlopen):
+        # Setup mock_urlopen response with Content-Length header that is too large
+        mock_response = MagicMock()
+        mock_response.headers = {"Content-Length": str(20 * 1024 * 1024)}  # 20MB
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        with self.assertRaisesRegex(ValueError, "Feed content too large"):
+            digest.fetch_feed_data_safely("https://some-feed.com", max_bytes=10 * 1024 * 1024)
+
+    @patch("digest.urllib.request.urlopen")
+    def test_fetch_feed_data_safely_oversized_stream(self, mock_urlopen):
+        # Setup mock_urlopen response returning more data than max_bytes
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        # First read returns 5 bytes, second read (the overflow check) returns b"x"
+        mock_response.read.side_effect = [b"abcde", b"x"]
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        with self.assertRaisesRegex(ValueError, "Feed content exceeds maximum size"):
+            digest.fetch_feed_data_safely("https://some-feed.com", max_bytes=5)
 
     @patch("digest.smtplib.SMTP_SSL")
     @patch("digest.os.getenv")


### PR DESCRIPTION
### 🚨 Severity: HIGH (DoS / Resource Exhaustion)

### 💡 Vulnerability
When consuming RSS feeds, `feedparser.parse(url)` fetches URLs using raw, unbounded urllib requests without response content length limits. Passing raw URLs directly to third-party parsing libraries exposes the application to resource exhaustion or decompression bomb payloads (OOM crashes) if external feed servers return excessively large payloads or infinite streams.

### 🔧 Fix
1. Implemented a robust `fetch_feed_data_safely` helper in `digest.py` to download feeds. It uses `urllib.request` with an explicit network `timeout`, a strict content size limit of `10MB` (from both headers and streaming reads), and a secure SSL/TLS context enforcing `TLSv1.2` minimum.
2. Modified `fetch_from_feed` to use `fetch_feed_data_safely` and pass raw bytes + headers to `feedparser.parse()`.
3. Added robust security tests in `test_security.py` to verify size validation and mock-based feed parser verification.
4. Updated the Sentinel journal `.jules/sentinel.md`.

### ✅ Verification
Ran `python3 -m unittest test_security.py` - all 14 unit tests passed perfectly.

---
*PR created automatically by Jules for task [13156807263795835162](https://jules.google.com/task/13156807263795835162) started by @kavyabarnadhya*