### PR TITLE
🎨 Palette: Improve skip-link absolute focus centering and dark mode contrast

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -3,10 +3,6 @@
 **Action:** Always verify color contrast using a tool (or standard darker hex codes) and use semantic headers (`<h3>`) even when the visual design requires inline styling to mimic spans.
 
 ## 2025-05-16 - [Scannability and Assistive Noise Reduction in Digests]
-**Learning:** For daily digests, scannability is paramount. Adding article counts to navigation and an estimated reading time significantly reduces the cognitive load for the user. Additionally, while emojis and decorative arrows provide visual delight, they create unnecessary noise for screen readers in an already dense email;  is essential for these elements.
-**Action:** Always include "at-a-glance" meta-info (counts, time) in headers and wrap all decorative glyphs in  spans.
-
-## 2025-05-16 - [Scannability and Assistive Noise Reduction in Digests]
 **Learning:** For daily digests, scannability is paramount. Adding article counts to navigation and an estimated reading time significantly reduces the cognitive load for the user. Additionally, while emojis and decorative arrows provide visual delight, they create unnecessary noise for screen readers in an already dense email; `aria-hidden="true"` is essential for these elements.
 **Action:** Always include "at-a-glance" meta-info (counts, time) in headers and wrap all decorative glyphs in `aria-hidden="true"` spans.
 
@@ -29,3 +25,7 @@
 ## 2026-07-19 - [Robust Programmatic Focus Management and Contrast in HTML Email Jumps]
 **Learning:** When using in-page skip-links and anchor links (e.g., jump-to-section) inside HTML emails, screen readers and key-based browsers often fail to redirect focus to non-interactive container targets (such as `<nav>`, `<main>`, and `<section>`). Setting `tabindex="-1"` on these target elements enables robust programmatic focus shifting, while suppressing browser-default visual focus rings with `[tabindex="-1"]:focus { outline: none !important; }` avoids visual clutter. Additionally, focus outlines on interactive components (like `.topic-pill`) must contrast sharply against parent card backgrounds (e.g. using theme colors like `#1a1a2e` in light mode, `#fff` in dark mode) to comply with WCAG 2.4.7.
 **Action:** Always use `tabindex="-1"` on target containers of skiplinks/anchor links and customize `:focus-visible` outline colors to contrast explicitly against the actual parent card or background.
+
+## 2026-07-20 - [Non-disruptive Skip-Links and Elevated Contrast in Dark Mode Email Readers]
+**Learning:** Skip-to-content links that display inline (`position: static`) upon receiving focus cause massive visual layout shifts that disrupt the reading flow. Centering focused links absolutely (`position: absolute; left: 50%; top: 10px; transform: translateX(-50%);`) solves this layout shift while keeping the focus element highly visible. Furthermore, default dark mode focus indicator outlines (like `#1a1a2e` on color categories) suffer from zero contrast on dark canvases; explicit white outlines (`#fff`) and elevated box-shadow highlights for container hovers/focuses are essential to preserve accessibility.
+**Action:** Design skip-links to overlay absolutely to prevent layout shifts, and override interactive focus styles with white outlines in prefers-color-scheme dark rules.

--- a/digest.py
+++ b/digest.py
@@ -678,14 +678,20 @@ def render_html(grouped, category_angles):
     }}
     .footer {{ text-align: center; padding: 20px; color: #5e5e5e; font-size: 12px; }}
     .skip-link:focus {{
-      position: static !important;
+      position: absolute !important;
+      left: 50% !important;
+      top: 10px !important;
+      transform: translateX(-50%) !important;
       width: auto !important;
       height: auto !important;
       overflow: visible !important;
-      background: #fff;
-      padding: 10px;
-      border: 2px solid #1a1a2e;
-      z-index: 9999;
+      background: #1a1a2e !important;
+      color: #fff !important;
+      padding: 10px 20px !important;
+      border: 2px solid #fff !important;
+      border-radius: 4px !important;
+      text-decoration: none !important;
+      z-index: 9999 !important;
     }}
     @media (prefers-color-scheme: dark) {{
       body {{ background: #121212 !important; color: #e0e0e0 !important; }}
@@ -701,6 +707,13 @@ def render_html(grouped, category_angles):
       .footer {{ color: #888 !important; }}
       .back-to-top a {{ color: #aaa !important; }}
       a:focus-visible {{ outline-color: #fff !important; }}
+      .topic-pill:hover, .topic-pill:focus-visible {{
+        outline-color: #fff !important;
+      }}
+      .article-card:hover, .article-card:focus-within {{
+        border-color: #666 !important;
+        box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05) !important;
+      }}
     }}
     @media print {{
       body {{ background: #fff !important; }}

--- a/test_security.py
+++ b/test_security.py
@@ -187,5 +187,37 @@ class TestSecurity(unittest.TestCase):
         import ssl
         self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
 
+    def test_rendered_html_css_improvements(self):
+        # Verify that our CSS improvements are correctly present in the rendered HTML
+        grouped = {
+            "Polity & Governance": [
+                {
+                    "title": "Article Title",
+                    "link": "https://example.com/art",
+                    "source": "The Hindu",
+                    "summary": "This is a summary mapping to GS-II."
+                }
+            ]
+        }
+        category_angles = {
+            "Polity & Governance": ["Exam relevance bullet point."]
+        }
+        html_body, _, _ = digest.render_html(grouped, category_angles)
+
+        # Check skip-link focus rule uses top/left/transform for centering absolute position
+        self.assertIn("position: absolute !important;", html_body)
+        self.assertIn("left: 50% !important;", html_body)
+        self.assertIn("top: 10px !important;", html_body)
+        self.assertIn("transform: translateX(-50%) !important;", html_body)
+        self.assertIn("background: #1a1a2e !important;", html_body)
+
+        # Check topic pill outline color on focus in dark mode
+        self.assertIn(".topic-pill:hover, .topic-pill:focus-visible", html_body)
+        self.assertIn("outline-color: #fff !important;", html_body)
+
+        # Check article-card hover state in dark mode
+        self.assertIn(".article-card:hover, .article-card:focus-within", html_body)
+        self.assertIn("box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05) !important;", html_body)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎨 Palette: Improve skip-link absolute focus centering and dark mode contrast

💡 What:
- Refined `.skip-link:focus` style to position absolutely at top center of viewport on keyboard focus, removing any visual layout shift.
- Applied high-contrast background and text colors to the skip-link element.
- Added white outline override for topic pills in prefers-color-scheme dark rules to guarantee accessibility compliance in dark mode.
- Added subtle box-shadow and border feedback on hover and focus-within for article cards in dark mode.
- Added comprehensive unit tests in test_security.py to prevent regression of rendering styles.

🎯 Why:
- Resolves visual layout shifts when screen-reader and keyboard users tab into the page.
- Ensures focus rings remain clearly visible in dark mode contexts (WCAG 2.4.7 compliant).

♿ Accessibility:
- Centers overlay absolutely to prevent shifting main content.
- Improves contrast ratio to conform to WCAG AA.

---
*PR created automatically by Jules for task [9915358686570286633](https://jules.google.com/task/9915358686570286633) started by @kavyabarnadhya*