### PR TITLE
🛡️ Sentinel: Fix SSRF via Redirects on Whitelisted Feeds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -45,3 +45,8 @@
 **Vulnerability:** Denial of Service (DoS) / Out-Of-Memory (OOM) crashes if external RSS feed servers return excessively large payloads or infinite streams during fetching.
 **Learning:** `feedparser.parse(url)` fetches URLs using raw, unbounded urllib requests without response content length limits. Passing raw URLs to third-party parsing libraries exposes the application to resource exhaustion or decompression bomb payloads.
 **Prevention:** Explicitly fetch RSS feed data using a custom `urllib.request` handler. Set an explicit network `timeout`, enforce a strict content length limit, truncate/verify stream data reading, use a secure SSL/TLS context enforcing `TLSv1.2` minimum, and pass parsed byte payloads and headers to `feedparser`.
+
+## 2026-07-26 - SSRF via Open Redirect on Whitelisted Domains
+**Vulnerability:** Server-Side Request Forgery (SSRF) bypass because `urllib.request` automatically follows HTTP/HTTPS redirects. Whitelisting the initial feed URLs does not prevent the remote server from redirecting the fetcher to internal/private resources or non-whitelisted domains.
+**Learning:** Whitelisting domains or URLs at the client level before triggering requests is insufficient when the underlying HTTP library automatically follows redirects. Redirect targets must be validated with the same security checks as the initial request.
+**Prevention:** Subclass `urllib.request.HTTPRedirectHandler` to intercept redirects and validate that the redirected URL (`newurl`) has a safe scheme (HTTP/HTTPS) and is present in the `ALLOWED_FEEDS` whitelist. Register this handler using `urllib.request.build_opener`.

--- a/digest.py
+++ b/digest.py
@@ -253,6 +253,21 @@ TOPIC_ORDER = [
 ]
 
 
+class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """
+    Security: Custom redirect handler to prevent Server-Side Request Forgery (SSRF)
+    via open redirects on whitelisted feed URLs.
+    """
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # Ensure redirect URL has a safe web protocol
+        if not isinstance(newurl, str) or not newurl.lower().startswith(("http://", "https://")):
+            raise ValueError(f"Secure protocol required for redirect: HTTP or HTTPS. Received: {newurl}")
+        # Enforce that redirect target is also in the ALLOWED_FEEDS whitelist
+        if newurl not in ALLOWED_FEEDS:
+            raise ValueError(f"Unauthorized redirect target: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 def fetch_feed_data_safely(url, timeout=15, max_bytes=10 * 1024 * 1024):
     """
     Security Enhancement: Safely fetch the RSS feed content with a strict size limit,
@@ -266,7 +281,12 @@ def fetch_feed_data_safely(url, timeout=15, max_bytes=10 * 1024 * 1024):
         url,
         headers={"User-Agent": "UPSC-News-Digest/1.0"}
     )
-    with urllib.request.urlopen(req, timeout=timeout, context=context) as response:
+    # Security: Build a secure opener that enforces redirect whitelisting
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPSHandler(context=context),
+        SafeRedirectHandler()
+    )
+    with opener.open(req, timeout=timeout) as response:
         content_length = response.headers.get("Content-Length")
         if content_length:
             try:

--- a/test_security.py
+++ b/test_security.py
@@ -143,14 +143,16 @@ class TestSecurity(unittest.TestCase):
         # The separator is \x00. We must ensure it's not in the result.
         self.assertNotIn("\x00", classified_encoded[0]["summary"])
 
-    @patch("digest.urllib.request.urlopen")
+    @patch("digest.urllib.request.build_opener")
     @patch("digest.feedparser.parse")
-    def test_fetch_from_feed_whitelist(self, mock_parse, mock_urlopen):
-        # Setup mock_urlopen to return mock data and headers safely
+    def test_fetch_from_feed_whitelist(self, mock_parse, mock_build_opener):
+        # Setup mock opener and response to return mock data and headers safely
+        mock_opener = MagicMock()
         mock_response = MagicMock()
         mock_response.read.side_effect = [b"<rss></rss>", b""]
         mock_response.headers = {"Content-Type": "text/xml"}
-        mock_urlopen.return_value.__enter__.return_value = mock_response
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
 
         # Setup mock_parse to return empty entries
         mock_parse.return_value.entries = []
@@ -169,27 +171,50 @@ class TestSecurity(unittest.TestCase):
         expected_headers = {"Content-Type": "text/xml", "content-location": authorized_url}
         mock_parse.assert_called_once_with(b"<rss></rss>", response_headers=expected_headers)
 
-    @patch("digest.urllib.request.urlopen")
-    def test_fetch_feed_data_safely_oversized_headers(self, mock_urlopen):
-        # Setup mock_urlopen response with Content-Length header that is too large
+    @patch("digest.urllib.request.build_opener")
+    def test_fetch_feed_data_safely_oversized_headers(self, mock_build_opener):
+        # Setup mock opener and response with Content-Length header that is too large
+        mock_opener = MagicMock()
         mock_response = MagicMock()
         mock_response.headers = {"Content-Length": str(20 * 1024 * 1024)}  # 20MB
-        mock_urlopen.return_value.__enter__.return_value = mock_response
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
 
         with self.assertRaisesRegex(ValueError, "Feed content too large"):
             digest.fetch_feed_data_safely("https://some-feed.com", max_bytes=10 * 1024 * 1024)
 
-    @patch("digest.urllib.request.urlopen")
-    def test_fetch_feed_data_safely_oversized_stream(self, mock_urlopen):
-        # Setup mock_urlopen response returning more data than max_bytes
+    @patch("digest.urllib.request.build_opener")
+    def test_fetch_feed_data_safely_oversized_stream(self, mock_build_opener):
+        # Setup mock opener and response returning more data than max_bytes
+        mock_opener = MagicMock()
         mock_response = MagicMock()
         mock_response.headers = {}
         # First read returns 5 bytes, second read (the overflow check) returns b"x"
         mock_response.read.side_effect = [b"abcde", b"x"]
-        mock_urlopen.return_value.__enter__.return_value = mock_response
+        mock_opener.open.return_value.__enter__.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
 
         with self.assertRaisesRegex(ValueError, "Feed content exceeds maximum size"):
             digest.fetch_feed_data_safely("https://some-feed.com", max_bytes=5)
+
+    def test_safe_redirect_handler_unauthorized(self):
+        handler = digest.SafeRedirectHandler()
+        # Non-whitelisted URL should raise ValueError
+        with self.assertRaisesRegex(ValueError, "Unauthorized redirect target"):
+            handler.redirect_request(None, None, 302, "Found", None, "https://unauthorized.domain.com/feed")
+
+    def test_safe_redirect_handler_invalid_scheme(self):
+        handler = digest.SafeRedirectHandler()
+        # Invalid scheme should raise ValueError
+        with self.assertRaisesRegex(ValueError, "Secure protocol required for redirect"):
+            handler.redirect_request(None, None, 302, "Found", None, "file:///etc/passwd")
+
+    def test_safe_redirect_handler_authorized(self):
+        handler = digest.SafeRedirectHandler()
+        authorized_url = list(digest.ALLOWED_FEEDS)[0]
+        with patch("urllib.request.HTTPRedirectHandler.redirect_request") as mock_super:
+            handler.redirect_request(None, None, 302, "Found", None, authorized_url)
+            mock_super.assert_called_once_with(None, None, 302, "Found", None, authorized_url)
 
     @patch("digest.smtplib.SMTP_SSL")
     @patch("digest.os.getenv")


### PR DESCRIPTION
Introduced a secure redirect handler subclassing HTTPRedirectHandler that validates redirect schemes (HTTP/HTTPS) and whitelists redirect URLs against `ALLOWED_FEEDS` to prevent Server-Side Request Forgery (SSRF) bypasses. Added three unit tests to verify secure redirect validation.

---
*PR created automatically by Jules for task [1508125748738571801](https://jules.google.com/task/1508125748738571801) started by @kavyabarnadhya*