### PR TITLE
🛡️ Sentinel: Harden control character checks in validate_env

### DIFF
--- a/digest.py
+++ b/digest.py
@@ -897,7 +897,7 @@ def validate_env():
             raise ValueError(f"Environment variable {var} exceeds maximum length of {max_len} characters.")
 
         # Security: Reject control characters to prevent header injection or other malformed input issues
-        if "\r" in val or "\n" in val:
+        if CONTROL_CHAR_RE.search(val) or "\r" in val or "\n" in val:
             raise ValueError(f"Environment variable {var} contains forbidden control characters.")
 
         # Security: Prevent usage of placeholder values from .env.example or common patterns

--- a/test_security.py
+++ b/test_security.py
@@ -76,6 +76,13 @@ class TestSecurity(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "contains forbidden control characters"):
                 digest.validate_env()
 
+        # Test control character (ESC) injection detection
+        env = self.valid_env.copy()
+        env["SENDER_APP_PASSWORD"] = "password\x1bwith_esc"
+        with patch.dict(os.environ, env, clear=True):
+            with self.assertRaisesRegex(ValueError, "contains forbidden control characters"):
+                digest.validate_env()
+
     def test_validate_env_large_input_dos(self):
         env = self.valid_env.copy()
         env["SENDER_APP_PASSWORD"] = "a" * 1000000


### PR DESCRIPTION
The UPSC News Digest application uses `validate_env()` to perform fail-fast environment checks on startup. Previously, this function checked for `\r` and `\n` to prevent header injection. 

This enhancement strengthens the check to reject all forbidden non-printable control characters by utilizing the existing pre-compiled regex `CONTROL_CHAR_RE`. This prevents any configuration, header, or terminal sequence injection risks via environment variables.

Additionally:
- Added a unit test in `test_security.py` to verify that environment variables containing control characters are correctly caught and rejected.
- Ran the full test suite to verify everything passes successfully.

---
*PR created automatically by Jules for task [7542970385463223167](https://jules.google.com/task/7542970385463223167) started by @kavyabarnadhya*