### PR TITLE
🎨 Palette: Add clickable article cards for touch-target UX enhancement

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2026-07-21 - [Print Optimization and Link Disclosure for Offline Study]
 **Learning:** For study-heavy content, users frequently print materials to study offline. Appending target URLs next to active anchor links (e.g., using `a::after { content: " (" attr(href) ")"; }`) ensures that printed copies retain the contextual resource information, while hiding interactive actions like "Read full article" reduces visual clutter and paper consumption.
 **Action:** Always include a print media query that hides interactive elements and dynamically reveals destination links beside the text anchors.
+
+## 2026-08-09 - [Accessible Stretched Links on Card Layouts]
+**Learning:** When implementing stretched links (making an entire card clickable using a pseudo-element `::after` on a nested anchor tag) for high touch-target accessibility (WCAG Target Size), sibling interactive elements and text content can be buried under the absolute overlay if not properly structured. Giving elements like paragraph text, tags, and detail links `position: relative` and a higher `z-index` restores their separate accessibility and text-selectability. Additionally, any print-specific layouts must override/reset these pseudo-elements to prevent overlay interference during hard-copy rendering.
+**Action:** Always use relative positioning with `z-index: 2` on text contents and secondary links inside a stretched-link container, and explicitly disable or reset the `::after` overlay within the `@media print` query.

--- a/digest.py
+++ b/digest.py
@@ -690,11 +690,30 @@ def render_html(grouped, category_angles):
       padding: 18px 20px;
       margin-bottom: 16px;
       display: block;
+      position: relative;
       transition: border-color 0.2s, box-shadow 0.2s;
     }}
     .article-card:hover, .article-card:focus-within {{
       border-color: #999 !important;
       box-shadow: 0 4px 12px rgba(0,0,0,0.1) !important;
+    }}
+    .article-title a::after {{
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 1;
+    }}
+    .read-more {{
+      font-size: 13px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: filter 0.2s, transform 0.2s;
+      display: inline-block;
+      position: relative;
+      z-index: 2;
     }}
     .gs-tag {{
       background: #1a1a2e;
@@ -705,7 +724,7 @@ def render_html(grouped, category_angles):
       letter-spacing: 0.5px;
       display: inline-block;
     }}
-    .article-title {{ margin: 0 0 8px 0; font-size: 17px; font-weight: 700; letter-spacing: 0.2px; }}
+    .article-title {{ margin: 0 0 8px 0; font-size: 17px; font-weight: 700; letter-spacing: 0.2px; position: relative; z-index: 2; }}
     .article-title a {{ color: #1a1a1a; text-decoration: none; }}
     .source-badge {{
       background: #f0f0f0;
@@ -715,19 +734,12 @@ def render_html(grouped, category_angles):
       padding: 3px 9px;
       border-radius: 12px;
     }}
-    .article-summary {{ color: #444; font-size: 14px; line-height: 1.6; margin: 0 0 12px 0; }}
-    .read-more {{
-      font-size: 13px;
-      font-weight: 600;
-      text-decoration: none;
-      transition: filter 0.2s, transform 0.2s;
-      display: inline-block;
-    }}
+    .article-summary {{ color: #444; font-size: 14px; line-height: 1.6; margin: 0 0 12px 0; position: relative; z-index: 2; }}
     .read-more:hover, .read-more:focus-visible {{
       filter: brightness(110%);
       transform: translateX(4px);
     }}
-    .source-container {{ margin-bottom: 10px; }}
+    .source-container {{ margin-bottom: 10px; position: relative; z-index: 2; }}
     .exam-angles {{
       background: #fefce8;
       border-left: 4px solid #f59e0b;
@@ -824,10 +836,12 @@ def render_html(grouped, category_angles):
       .skip-link, .topic-index, .back-to-top, .read-more {{ display: none !important; }}
       .article-card, .exam-angles {{ break-inside: avoid; border: 1px solid #eee !important; }}
       .article-title a::after {{
-        content: " (" attr(href) ")";
-        font-weight: normal;
-        font-size: 13px;
-        color: #555;
+        content: " (" attr(href) ")" !important;
+        position: static !important;
+        z-index: auto !important;
+        font-weight: normal !important;
+        font-size: 13px !important;
+        color: #555 !important;
       }}
       .footer {{ border-top: 1px solid #eee; margin-top: 20px; }}
     }}


### PR DESCRIPTION
Implemented a micro-UX enhancement on the news digest email template to make the entire article card clickable. Set `.article-card` as relative and layered `.article-title a::after` as an absolute pseudo-element covering the card. Sibling interactive content and text are elevated with relative positioning and z-indexes for accessibility. Print styles are updated to reset overlays. Verified visual layout and executed unit tests successfully.

---
*PR created automatically by Jules for task [5609127186907714296](https://jules.google.com/task/5609127186907714296) started by @kavyabarnadhya*