### PR TITLE
🛡️ Sentinel: Fix LLM index type confusion and defensive typing

### DIFF
--- a/digest.py
+++ b/digest.py
@@ -74,7 +74,12 @@ def clean_text(text, max_len=2000, strip_tags=True):
     Performance Optimization: Strips HTML tags and unescapes entities from text.
     Fast-path check uses CONTROL_CHAR_RE.search before substitution to avoid regex sub overhead.
     Security: Strips control characters after unescaping to prevent bypasses.
+    Defensive Typing: Ensures non-string inputs are converted to str to prevent TypeError.
     """
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
     if not text:
         return ""
     # Optimization: Truncate raw input early to avoid expensive processing on large payloads
@@ -435,7 +440,8 @@ def process_llm_articles(articles, data):
         if topic == "Not UPSC Relevant" or topic not in TOPIC_COLORS:
             continue
         # Security: Validate index is a non-negative integer within bounds AND not already processed
-        if not isinstance(idx, int) or idx < 0 or idx >= len(articles) or idx in seen_indices:
+        # Reject boolean type explicitly since in Python bool subclasses int (isinstance(True, int) is True)
+        if type(idx) is not int or idx < 0 or idx >= len(articles) or idx in seen_indices:
             continue
 
         seen_indices.add(idx)

--- a/test_security.py
+++ b/test_security.py
@@ -345,6 +345,32 @@ class TestSecurity(unittest.TestCase):
         self.assertIn("Economy", angles)
         self.assertNotIn("Invalid Hallucinated Topic", angles)
 
+    def test_process_llm_articles_rejects_boolean_index_type_confusion(self):
+        # Python booleans subclass int: isinstance(True, int) is True, True == 1, False == 0.
+        # Ensure process_llm_articles rejects boolean indices from untrusted LLM output.
+        articles = [
+            {"title": "Art 0", "link": "http://l0", "source": "S0", "summary": "Sum0"},
+            {"title": "Art 1", "link": "http://l1", "source": "S1", "summary": "Sum1"},
+        ]
+        llm_data = {
+            "articles": [
+                {"index": True, "topic": "Economy", "summary": "SumTrue"},
+                {"index": False, "topic": "Economy", "summary": "SumFalse"},
+                {"index": 1, "topic": "Economy", "summary": "Valid index 1"}
+            ]
+        }
+        classified, _ = digest.process_llm_articles(articles, llm_data)
+        self.assertEqual(len(classified), 1)
+        self.assertEqual(classified[0]["title"], "Art 1")
+        self.assertEqual(classified[0]["summary"], "Valid index 1")
+
+    def test_clean_text_defensive_typing(self):
+        # Non-string inputs (integers, booleans, dicts, None) should be handled safely
+        self.assertEqual(digest.clean_text(None), "")
+        self.assertEqual(digest.clean_text(12345), "12345")
+        self.assertEqual(digest.clean_text(True), "True")
+        self.assertEqual(digest.clean_text({"key": "val"}), "{'key': 'val'}")
+
     @patch("digest.os.getenv")
     def test_send_email_raises_on_missing_credentials(self, mock_getenv):
         mock_getenv.side_effect = lambda key, default="": ""


### PR DESCRIPTION
### Summary of Security Fixes:
1. **LLM Index Type Confusion Mitigation:** In Python, `bool` is a subclass of `int` (`isinstance(True, int)` is `True`). Untrusted LLM outputs returning `{"index": true}` or `{"index": false}` previously passed `isinstance(idx, int)` checks and resolved to article indices `1` and `0`. Updating the validation check to `type(idx) is not int` strictly ensures that only native integers are accepted.
2. **Defensive Input Handling:** Enhanced `clean_text` to check for `None` and convert non-string types to `str` before slicing, preventing unhandled `TypeError` exceptions from unexpected dynamic objects.
3. **Security Unit Tests:** Added `test_process_llm_articles_rejects_boolean_index_type_confusion` and `test_clean_text_defensive_typing` to `test_security.py`. All 27 unit tests pass cleanly.

---
*PR created automatically by Jules for task [10517547456832197087](https://jules.google.com/task/10517547456832197087) started by @kavyabarnadhya*