### PR TITLE
🎨 Palette: Add external link ARIA labels and semantic aside landmark

### DIFF
--- a/digest.py
+++ b/digest.py
@@ -613,7 +613,7 @@ def render_html(grouped, category_angles):
             cards_parts.append(f"""
             <article class="article-card" style="border-left-color:{color};">
               <h3 class="article-title">
-                <a href="{safe_link}" target="_blank" rel="noopener noreferrer">{safe_title}</a>
+                <a href="{safe_link}" target="_blank" rel="noopener noreferrer" aria-label="{safe_title} (opens in new tab)">{safe_title}</a>
               </h3>
               <div class="source-container">
                 <span class="source-badge">{source_icon}{safe_source}</span>
@@ -630,14 +630,15 @@ def render_html(grouped, category_angles):
         angles_html = ""
         if angles:
             bullets = "".join([f'<li class="exam-angle-bullet">{b}</li>' for b in angles])
+            angles_header_id = f"angles-header-{anchor}"
             angles_html = f"""
-          <div class="exam-angles">
-            <h3 class="exam-angles-header">
+          <aside class="exam-angles" aria-labelledby="{angles_header_id}">
+            <h3 id="{angles_header_id}" class="exam-angles-header">
               <span aria-hidden="true">🎓</span> UPSC Exam Angles
             </h3>
             <ul class="exam-angles-list">{bullets}</ul>
             {BACK_TO_TOPICS_SMALL_HTML}
-          </div>"""
+          </aside>"""
 
         # Optimization: Use pre-calculated topic header fragments
         header_html = TOPIC_HEADERS_HTML.get(topic, SAFE_TOPIC_NAMES.get(topic, topic))

--- a/test_security.py
+++ b/test_security.py
@@ -326,6 +326,13 @@ class TestSecurity(unittest.TestCase):
         self.assertIn(".article-card:hover, .article-card:focus-within", html_body)
         self.assertIn("box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05) !important;", html_body)
 
+        # Check title link aria-label for external links
+        self.assertIn('aria-label="Article Title (opens in new tab)"', html_body)
+
+        # Check exam angles semantic landmark <aside> with aria-labelledby
+        self.assertIn('<aside class="exam-angles" aria-labelledby="angles-header-polity-and-governance">', html_body)
+        self.assertIn('<h3 id="angles-header-polity-and-governance" class="exam-angles-header">', html_body)
+
         # Check read-more accessibility and card hover animation
         self.assertIn('class="read-more" aria-label="Read full article: Article Title (opens in new tab)"', html_body)
         self.assertIn('target="_blank" rel="noopener noreferrer"', html_body)


### PR DESCRIPTION
Implemented micro-UX and accessibility improvements:
1. Added descriptive `aria-label` with `(opens in new tab)` to article title links in `render_html()` so screen reader users navigating headings receive clear context on link targets.
2. Converted the UPSC Exam Angles callout block from generic `<div>` to a semantic `<aside class="exam-angles" aria-labelledby="...">` landmark bound to its `<h3>` header ID for enhanced landmark navigation.
3. Updated unit test assertions in `test_security.py` and confirmed all 27 unit tests pass.

---
*PR created automatically by Jules for task [3119157394405341563](https://jules.google.com/task/3119157394405341563) started by @kavyabarnadhya*